### PR TITLE
Change to use donotcommit.com for API

### DIFF
--- a/ignr/cli.py
+++ b/ignr/cli.py
@@ -1,7 +1,8 @@
 import argparse, os, sys
-from . import gitignoreio_api as api
+from .gitignoreio_api import GitignoreIOAPI
 
 parser = argparse.ArgumentParser(prog="python -m ignr" if "__main__" in sys.argv[0] else "ignr")
+parser.add_argument('--base-url', '-b', dest='base_url', metavar='URL', help='base url for api to fetch gitignore templates')
 
 # Accept list instruction, search instruction, OR create instruction
 task = parser.add_mutually_exclusive_group(required=True)
@@ -11,6 +12,8 @@ task.add_argument('--new', '-n', dest='n_stack', metavar='TECH', nargs='+', help
 task.add_argument('--preview', '-p', dest='p_stack', metavar='TECH', nargs='+', help='preview for space-separated technologies')
 
 args = parser.parse_args()
+
+api = GitignoreIOAPI(args.base_url)
 
 # --list or --search
 if args.list or args.s_term:

--- a/ignr/gitignoreio_api.py
+++ b/ignr/gitignoreio_api.py
@@ -2,29 +2,35 @@ from urllib import request
 
 headers = {'User-Agent': 'ignr.py'}
 
-def get_template_list():
-    response = request.urlopen(
-        request.Request('https://www.gitignore.io/api/list', headers=headers)
-    ).read().decode('utf-8')
+BASE_URL = 'https://donotcommit.com'
+
+
+class GitignoreIOAPI:
+    def __init__(self, base_url=BASE_URL):
+        self.base_url = base_url
+
+    def request(self, url):
+        return request.urlopen(
+            request.Request(self.base_url + url, headers=headers)
+        ).read().decode('utf-8')
     
-    template_list = []
-    for line in map(str, response.split('\n')):
-        template_list.extend(line.split(','))
+    def get_template_list(self):
+        response = self.request('/api/list')
+        
+        template_list = []
+        for line in map(str, response.split('\n')):
+            template_list.extend(line.split(','))
 
-    return template_list
+        return template_list
 
-# gi_stack is a list of strings of names of tech to include
-# ex. ['sass', 'node', 'macos']
-def get_gitignore(gi_stack):
-    template_list = get_template_list()
+    def get_gitignore(self, gi_stack):
+        template_list = self.get_template_list()
 
-    for tech in gi_stack:
-        if tech.lower() not in template_list:
-            raise ValueError(tech)  # Reports iffy item in the list
+        for tech in gi_stack:
+            if tech.lower() not in template_list:
+                raise ValueError(tech)  # Reports iffy item in the list
 
-    comma_delimited = ','.join(gi_stack)
-    response = request.urlopen(
-        request.Request('https://www.gitignore.io/api/' + comma_delimited, headers=headers)
-    ).read().decode('utf-8')
+        comma_delimited = ','.join(gi_stack)
+        response = self.request('/api/' + comma_delimited)
 
-    return response
+        return response

--- a/ignr/gitignoreio_api.py
+++ b/ignr/gitignoreio_api.py
@@ -6,10 +6,10 @@ BASE_URL = 'https://donotcommit.com'
 
 
 class GitignoreIOAPI:
-    def __init__(self, base_url=BASE_URL):
-        self.base_url = base_url
+    def __init__(self, base_url):
+        self.base_url = base_url or BASE_URL
 
-    def request(self, url):
+    def request(self, url = '/'):
         return request.urlopen(
             request.Request(self.base_url + url, headers=headers)
         ).read().decode('utf-8')


### PR DESCRIPTION
Hello! This is a little drive by PR to replace `https://www.gitignore.io` with `https://donotcommit.com`.

I don't know the full story, but [Toptal](https://www.toptal.com) (a recruiting company) are now in control of `gitignore.io` - it's been this way for a while.

I think the code here used to work, but there's now (or always was) a JavaScript redirect on `gitignore.io` which breaks this client.

I was going to change to point to `https://www.toptal.com/developers/gitignore/api/`, which works fine, but toptal/gitignore.io#662 made me think twice. Instead I've opted for [somosofficina/donotcommit](https://github.com/somosofficina/donotcommit) which offers a compaitable API - but I guess in the end who knows how long that will be around either.